### PR TITLE
change version to 0.2.0 for embulk v0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
     mavenCentral()
 }
 
-version = "0.1.1"
+version = "0.2.0"
 
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.31"


### PR DESCRIPTION
Change this plugin version from 0.1.1 to 0.2.0 for embulk v0.10.
