### PR TITLE
Revert "Add FileOutput.finish() in Provider.finish()"

### DIFF
--- a/src/main/java/org/embulk/encoder/CommonsCompressArchiveProvider.java
+++ b/src/main/java/org/embulk/encoder/CommonsCompressArchiveProvider.java
@@ -67,28 +67,23 @@ class CommonsCompressArchiveProvider implements OutputStreamFileOutput.Provider 
         return tmpOut = new ByteArrayOutputStream();
     }
 
-    private void archive() throws IOException {
-        if (tmpOut == null) {
-            return;
-        }
-        archiveOut = createArchiveOutputStream();
-        archiveOut.putArchiveEntry(createEntry(tmpOut.size()));
-        archiveOut.write(tmpOut.toByteArray());
-        archiveOut.closeArchiveEntry();
-        archiveOut.finish();
-        tmpOut = null;
-    }
-
     @Override
     public void finish() throws IOException {
-        archive();
-        underlyingFileOutput.finish();
+        if (tmpOut != null) {
+            archiveOut = createArchiveOutputStream();
+            archiveOut.putArchiveEntry(createEntry(tmpOut.size()));
+            archiveOut.write(tmpOut.toByteArray());
+            archiveOut.closeArchiveEntry();
+            archiveOut.finish();
+            tmpOut = null;
+        }
     }
 
     @Override
     public void close() throws IOException {
-        archive();
-
+        if (tmpOut != null) {
+            finish();
+        }
         if (archiveOut != null) {
             archiveOut.close();
             archiveOut = null;

--- a/src/test/java/org/embulk/encoder/TestCommonsCompressArchiveProvider.java
+++ b/src/test/java/org/embulk/encoder/TestCommonsCompressArchiveProvider.java
@@ -96,6 +96,7 @@ public class TestCommonsCompressArchiveProvider {
     }
 
     @Test
+    @Ignore // TODO: bug fix
     public void testFinish() throws Exception {
         new NonStrictExpectations() {{
             task.getFormat(); result = "zip";


### PR DESCRIPTION
FileOutput.finish() should be called in CommonsCompressArchiveProvider.finish(), but it causes BufferDoubleReleasedException in [embulk v0.10.0](https://github.com/hata/embulk-encoder-commons-compress/pull/3).
It is not only with embulk-output-sftp but embulk-ouptut-file, so I want to revert this PR untill I find the correct solution.
（If other problems found,  I may need to revert v0.10.0 PR.）

※ The reason I noticed it late was because the location of classpath output in v0.9 and v0.10 was different, and I done test with old code.

```
org.embulk.deps.buffer.PooledBufferAllocatorImpl$BufferDoubleReleasedException: A Buffer detected double release() calls. The buffer has already been released at:
	at org.embulk.deps.buffer.PooledBufferAllocatorImpl$BufferBasedOnNettyByteBuf.release(PooledBufferAllocatorImpl.java:40)
	at org.embulk.standards.LocalFileOutputPlugin$1.add(LocalFileOutputPlugin.java:109)
	at org.embulk.util.file.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:88)
	at org.embulk.util.file.FileOutputOutputStream.close(FileOutputOutputStream.java:107)
	at org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream.destroy(ZipArchiveOutputStream.java:1951)
	at org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream.close(ZipArchiveOutputStream.java:1122)
	at org.embulk.encoder.CommonsCompressArchiveProvider.close(CommonsCompressArchiveProvider.java:93)
	at org.embulk.util.file.OutputStreamFileOutput.close(OutputStreamFileOutput.java:82)
	at org.embulk.spi.util.LineEncoder.close(LineEncoder.java:106)
	at org.embulk.standards.CsvFormatterPlugin$1.close(CsvFormatterPlugin.java:198)
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.close(FileOutputRunner.java:159)
	at org.embulk.spi.CloseResource.close(CloseResource.java:25)
	at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput.close(LocalExecutorPlugin.java:453)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:281)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$100(LocalExecutorPlugin.java:194)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:233)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:230)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.Throwable
	at org.embulk.deps.buffer.PooledBufferAllocatorImpl$BufferBasedOnNettyByteBuf.release(PooledBufferAllocatorImpl.java:45)
	at org.embulk.standards.LocalFileOutputPlugin$1.add(LocalFileOutputPlugin.java:109)
	at org.embulk.util.file.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:88)
	at org.embulk.util.file.FileOutputOutputStream.close(FileOutputOutputStream.java:107)
	at org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream.destroy(ZipArchiveOutputStream.java:1951)
	at org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream.close(ZipArchiveOutputStream.java:1122)
```
