### PR TITLE
Fix  BufferDoubleReleasedException

### DIFF
--- a/src/main/java/org/embulk/encoder/CommonsCompressArchiveProvider.java
+++ b/src/main/java/org/embulk/encoder/CommonsCompressArchiveProvider.java
@@ -76,6 +76,7 @@ class CommonsCompressArchiveProvider implements OutputStreamFileOutput.Provider 
         archiveOut.write(tmpOut.toByteArray());
         archiveOut.closeArchiveEntry();
         archiveOut.finish();
+        output.flush();
         tmpOut = null;
     }
 


### PR DESCRIPTION
Support embulk v0.10.0 and FileOuput.finish calling caused　BufferDoubleReleasedException when using archive format (zip, tar...).
I just wanted to inform you about this PR that makes the error suppress.

Or apply the [revert PR](https://github.com/hata/embulk-encoder-commons-compress/pull/6).