### PR TITLE
Fix integration test for embulk v0.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,5 +55,13 @@ tasks.withType(JavaCompile) {
 // To enable integrationTest, run like this:
 // ./gradlew -DenableIntegrationTest=true gem
 
-project.tasks.integrationTest.dependsOn(jar)
+// classpath task is for compatibility of integartion-test before embulk v0.10.0.
+task classpath(type: Copy, dependsOn: ["jar"]) {
+    doFirst { file("classpath").deleteDir() }
+    from(configurations.runtime - configurations.compileOnly + files(jar.archivePath))
+    into "classpath"
+}
+clean { delete 'classpath' }
+
+project.tasks.integrationTest.dependsOn(classpath)
 gem.dependsOn(check)

--- a/src/integration-test/resources/config_zip.yml
+++ b/src/integration-test/resources/config_zip.yml
@@ -1,0 +1,27 @@
+in:
+  type: file
+  path_prefix: ./sample_1.csv
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ','
+    quote: '"'
+    trim_if_not_quoted: false
+    skip_header_lines: 1
+    allow_extra_columns: false
+    allow_optional_columns: false
+    columns:
+    - {name: id, type: long}
+    - {name: comment, type: string}
+out:
+  type: file
+  path_prefix: ./result_zip_
+  file_ext: csv.zip
+  formatter:
+    type: csv
+    quote_policy: MINIMAL
+    newline: LF
+  encoders:
+  - type: commons-compress
+    format: zip


### PR DESCRIPTION
Currently `./gradlew -DenableIntegrationTest=true gem` fail, because classpath is not made by the latest embulk version (If integration-test can execute, it used classpath made by embulk v0.9.0.).
I want to solve this problem,  added the classpath task to build.gradle.

I also add zip test to integration-test.
